### PR TITLE
Revert "defining flag OPENFLOW_ENABLE when compiling OF plugin"

### DIFF
--- a/p4c_bm/plugin/p4c-plugin.mk
+++ b/p4c_bm/plugin/p4c-plugin.mk
@@ -7,5 +7,4 @@ endif
 
 ifdef PLUGIN_OPENFLOW
 include ${P4FACTORY}/submodules/p4c-behavioral/p4c_bm/plugin/openflow-plugin.mk
-BM_PARAMS += -DOPENFLOW_ENABLE
 endif


### PR DESCRIPTION
Reverts p4lang/p4c-behavioral#22
