### PR TITLE
sai_p4 build fix

### DIFF
--- a/p4c-bm.mk
+++ b/p4c-bm.mk
@@ -45,9 +45,6 @@ ifdef BM_P4_META_CONFIG
   BM_PARAMS += --meta-config=${BM_P4_META_CONFIG}
 endif
 
-# compile the plugins
-include $(THIS_DIR)/p4c_bm/plugin/p4c-plugin.mk
-
 BM_TEMPLATES_C := $(wildcard ${THIS_DIR}/p4c_bm/templates/src/*.c)
 BM_TEMPLATES_H := $(wildcard ${THIS_DIR}/p4c_bm/templates/src/*.h)
 BM_TEMPLATES_H += $(wildcard ${THIS_DIR}/p4c_bm/templates/src/*.ipp)
@@ -55,6 +52,9 @@ BM_TEMPLATES_CPP := $(wildcard ${THIS_DIR}/p4c_bm/templates/src/*.cpp)
 BM_TEMPLATES_PUBLIC_HEADERS := $(wildcard ${THIS_DIR}/p4c_bm/templates/inc/*.h)
 BM_TEMPLATES_THRIFT := $(wildcard ${THIS_DIR}/p4c_bm/templates/thrift/*.thrift)
 BM_TEMPLATES := ${BM_TEMPLATES_C} ${BM_TEMPLATES_H} ${BM_TEMPLATES_CPP} ${BM_TEMPLATES_PUBLIC_HEADERS} ${BM_TEMPLATES_THRIFT}
+
+# compile the plugins
+include $(THIS_DIR)/p4c_bm/plugin/p4c-plugin.mk
 
 BM_TENJIN_OUTPUT_C := $(addprefix ${BM_BUILD_SRC_DIR}/, $(notdir ${BM_TEMPLATES_C}))
 BM_TENJIN_OUTPUT_H := $(addprefix ${BM_BUILD_DIR}/src/, $(notdir ${BM_TEMPLATES_H}))


### PR DESCRIPTION
When building SAI, p4c-plugin.mk includes sai-plugin.mk, which includes p4factory's thrift-py.mk, which modifies THIS_DIR. Moving the inclusion of p4c-plugin.mk below all other references to THIS_DIR fixes this.
